### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Timestamp library for Arduino
 paragraph=This is a timestamp library to measure execution durations in microseconds or milliseconds resolution.
 category=Timing
 url=https://github.com/Erriez/ArduinoLibraryTimestamp
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format